### PR TITLE
Drop template provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,16 @@ A Terraform module to create an Amazon Web Services (AWS) EC2 Container Service 
 ## Usage
 
 ```hcl
-data "template_file" "container_instance_cloud_config" {
-  template = "${file("container-instance.yml.tpl")}"
- 
-  vars = {
-    environment = "${var.environment}"
-  }
-}
-
 module "container_service_cluster" {
-  source = "github.com/kgirthofer/ecs_cluster_tf?ref=0.1.0"
+  source = "github.com/kgirthofer/ecs_cluster_tf?ref=0.6.6"
 
   vpc_id        = "vpc-3b57ce53"
   ami_id        = "ami-04351e12"
   instance_type = "t2.micro"
   key_name      = "prod"
-  cloud_config  = "${data.template_file.container_instance_cloud_config.rendered}"
+  cloud_config  = templatefile("container-instance.yml.tpl"), {
+    environment = var.environment
+  })
 
   root_block_device_type = "gp2"
   root_block_device_size = "10"

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -1,21 +1,15 @@
 #
 # AutoScaling resources
 #
-data "template_file" "container_instance_base_cloud_config" {
-  template = "${file("${path.module}/cloud-config/base-container-instance.yml.tpl")}"
-
-  vars = {
-    ecs_cluster_name = "${aws_ecs_cluster.container_instance.name}"
-  }
-}
-
 data "template_cloudinit_config" "container_instance_cloud_config" {
   gzip          = false
   base64_encode = false
 
   part {
     content_type = "text/cloud-config"
-    content      = "${data.template_file.container_instance_base_cloud_config.rendered}"
+    content      = templatefile("${path.module}/cloud-config/base-container-instance.yml.tpl", {
+      ecs_cluster_name = aws_ecs_cluster.container_instance.name
+    })
   }
 
   part {

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -39,7 +39,7 @@ resource "aws_launch_configuration" "container_instance" {
   image_id             = "${var.ami_id}"
   instance_type        = "${var.instance_type}"
   key_name             = "${var.key_name}"
-  security_groups      = ["${var.security_groups}"]
+  security_groups      = var.security_groups
   user_data            = "${data.template_cloudinit_config.container_instance_cloud_config.rendered}"
 }
 


### PR DESCRIPTION
Drop the template provider.  It's deprecated and isn't released for darwin_arm64 (Mac M1).  Use the `templatefile` function instead.

CC @shawncatz @kiamatt 